### PR TITLE
chore: remove typescript dependency

### DIFF
--- a/web-app-demo/Frontend/package-lock.json
+++ b/web-app-demo/Frontend/package-lock.json
@@ -47,8 +47,7 @@
         "karma-chrome-launcher": "3.1.1",
         "karma-coverage": "2.2.0",
         "karma-jasmine": "5.1.0",
-        "karma-jasmine-html-reporter": "2.0.0",
-        "typescript": "4.8.2"
+        "karma-jasmine-html-reporter": "2.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -11948,6 +11947,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
       "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -21404,7 +21404,8 @@
       "version": "4.8.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
       "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "ua-parser-js": {
       "version": "0.7.32",

--- a/web-app-demo/Frontend/package.json
+++ b/web-app-demo/Frontend/package.json
@@ -50,7 +50,6 @@
     "karma-chrome-launcher": "3.1.1",
     "karma-coverage": "2.2.0",
     "karma-jasmine": "5.1.0",
-    "karma-jasmine-html-reporter": "2.0.0",
-    "typescript": "4.8.2"
+    "karma-jasmine-html-reporter": "2.0.0"
   }
 }


### PR DESCRIPTION
Angular is already pulling in TypeScript. Often its required version conflicts with the latest TypeScript available.