### PR TITLE
Fix to create reference table using the proper relative path

### DIFF
--- a/bq-connector/setup/create_doc_reference_table.sh
+++ b/bq-connector/setup/create_doc_reference_table.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 bq mk \
   --table \
   --project_id=$PROJECT_ID \
   --dataset_id=$DATASET_ID \
   --description="Used by docai_bq_connector to keep track of documents processed and to match up results of HITL reviews back to the original document" \
-  --schema="./doc_reference_table_schema.json" \
+  --schema="$DIR/doc_reference_table_schema.json" \
   "$DATASET_ID.doc_reference"


### PR DESCRIPTION
- Fix relative path, otherwise instructions to run ./setup/create_doc_referente_table_schema.sh cannot work and will give following Error:
`- BigQuery error in mk operation: Error reading schema: "./doc_reference_table_schema.json" looks like a filename, but was not found.`