### PR TITLE
chore: update dependency update schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,14 @@
         "devDependencies"
       ],
       "automerge": true
+    },
+    {
+      "matchUpdateTypes": ["minor"],
+      "extends": ["schedule:monthly"]
+    },
+    {
+      "matchUpdateTypes": ["patch"],
+      "extends": ["schedule:quarterly"]
     }
   ],
   "pip_requirements": {
@@ -33,5 +41,8 @@
       "constraints.txt",
       "constraints-test.txt"
     ]
+  },
+  "vulnerabilityAlerts": {
+    "schedule": ["at any time"]
   }
 }


### PR DESCRIPTION
- Update Renovate config so that minor PRs are submitted monthly, and patch PRs are submitted quarterly. Schedule can be updated at any time.