### PR TITLE
Update broken GAB links

### DIFF
--- a/document-search/templates/ekg.html
+++ b/document-search/templates/ekg.html
@@ -362,7 +362,7 @@
         Made by <a href="https://github.com/holtskinner">holtskinner@</a> -
         Source on
         <a
-          href="https://github.com/GoogleCloudPlatform/generative-ai/gen-app-builder/search-web-app"
+          href="https://github.com/GoogleCloudPlatform/document-ai-samples/tree/main/document-search"
           >GitHub</a
         >
       </p>

--- a/document-search/templates/index.html
+++ b/document-search/templates/index.html
@@ -92,7 +92,7 @@
         Made by <a href="https://github.com/holtskinner">holtskinner@</a> -
         Source on
         <a
-          href="https://github.com/GoogleCloudPlatform/generative-ai/gen-app-builder/search-web-app"
+          href="https://github.com/GoogleCloudPlatform/document-ai-samples/tree/main/document-search"
           >GitHub</a
         >
       </p>

--- a/document-search/templates/search.html
+++ b/document-search/templates/search.html
@@ -250,7 +250,7 @@
         Made by <a href="https://github.com/holtskinner">holtskinner@</a> -
         Source on
         <a
-          href="https://github.com/GoogleCloudPlatform/generative-ai/gen-app-builder/search-web-app"
+          href="https://github.com/GoogleCloudPlatform/document-ai-samples/tree/main/document-search"
           >GitHub</a
         >
       </p>


### PR DESCRIPTION
GH Source links on https://genappbuilder-demo-lnppzg3rxa-uc.a.run.app/ are currently pointing to `404`s